### PR TITLE
change paths to the js/css files in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ bower install angular-rateit
 And add the files to your index page:
 
 ```html
-<link rel="stylesheet" href="angular-rateit/dist/rateit.css" />
-<script src="angular-rateit/dist/rateit.js"></script>
+<link rel="stylesheet" href="angular-rateit/dist/ng-rateit.css" />
+<script src="angular-rateit/dist/ng-rateit.js"></script>
 ```
 
 Finally add 'ngRateIt' to your main module's list of dependencies:


### PR DESCRIPTION
Hi, I included this lib to my project, but I had some issues with including it... I could not understand why ngRateIt module is not found. I was sure that path to the files is correct because I copied it from README file of the project. 

But js and css file are prefixed with `ng-` and that's why they were not loaded (and that's why ngRateIt module was undefined). 

This pull request just changes README.md
